### PR TITLE
Ensure SDK setup doesn't pollute report output

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -22,17 +22,12 @@ def setup_oauth2()
     verification_code = gets.chomp
     verification_code
   end
-  if token
-    unless verification_code.nil?
-      print "\nWould you like to update your adwords_api.yml to save " +
-          "OAuth2 credentials? (y/N): "
-      response = gets.chomp
-    end
-    if response.nil? or ('y'.casecmp(response) == 0) or ('yes'.casecmp(response) == 0)
-      @adwords.save_oauth2_token(token)
-      puts 'OAuth2 token is now saved to ~/adwords_api.yml and will be ' +
-          'automatically used by the library.'
-    end
+  if verification_code && token
+    puts 'Updating adwords_api.yml with OAuth credentials.'
+    @adwords.save_oauth2_token(token)
+    puts 'OAuth2 token is now saved and will be automatically used by the library.'
+    puts 'Please restart the script now.'
+    abort
   end
 
   # Alternatively, you can provide one within the parameters:

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,8 @@
 export HOME=`pwd`
 
 file="adwords_api.yml"
-if [ -f "$file" ]
+if [ ! -f "$file" ]
 then
-  echo 'File exists. ruby main.rb....'
-else
   cat > $file <<- EOM
 ---
 # This is an example configuration file for the AdWords API client library.


### PR DESCRIPTION
Note that this forces the overriding of `adwords_api.yml` with OAuth2
data by the SDK. Not a big deal, since the SDK does a backup of the file
before replacing it.